### PR TITLE
Map link/britney

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -28,8 +28,20 @@ class Location < ActiveRecord::Base
     self.reviews.count("#{attr} > 0") >=1
   end
 
+  def escaped_name
+    self.name.gsub(" ","+")
+  end
+
   def escaped_address
-    self.name.gsub(" ","+") + "+" + self.formatted_address.gsub(" ","+")
+    self.formatted_address.gsub(" ","+").gsub(",+United+States","")
+  end
+
+  def query_string
+    self.escaped_name + "+" + self.escaped_address
+  end
+
+  def directions_url
+    "https://www.google.com/maps/dir/Current+Location/" + self.query_string
   end
 
   def reviews?

--- a/app/views/locations/_heading.html.erb
+++ b/app/views/locations/_heading.html.erb
@@ -1,5 +1,5 @@
 <div class="page_heading">
   <h2><%= location.name %></h2>
-  <div="location_address"><%= location.formatted_address %></div>
+  <div="location_address"><%= link_to location.formatted_address, location.directions_url %></div>
   <div="location_name"><%= location.formatted_phone_number %></div>
 </div>

--- a/app/views/locations/_map.html.erb
+++ b/app/views/locations/_map.html.erb
@@ -1,6 +1,6 @@
 <div class="location_map">
   <iframe
   frameborder="0" style="border:0"
-  src="https://www.google.com/maps/embed/v1/place?key=<%= ENV["GMAPS"] %>&q=<%= location.escaped_address %>" allowfullscreen>
+  src="https://www.google.com/maps/embed/v1/place?key=<%= ENV["GMAPS"] %>&q=<%= location.query_string %>" allowfullscreen>
 </iframe>
 </div>


### PR DESCRIPTION
This link ended up being pretty helpful, detailing the different Google map url options: https://gearside.com/easily-link-to-locations-and-directions-using-the-new-google-maps/

I implemented the directions from current location for the address on the location show pages. The method in the location model is direction_url and it's built off of other methods that format the location name and address as needed. Should be helpful for #57  
